### PR TITLE
Tandem method changes with virtual and override

### DIFF
--- a/src/PlugIn.cs
+++ b/src/PlugIn.cs
@@ -86,7 +86,7 @@ namespace Landis.Extension.LinearWind
             //log.WriteLine("Time,Initiation Site,Total Sites,Damaged Sites,Cohorts Killed,Mean Severity");
         }
         //---------------------------------------------------------------------
-        public new void InitializePhase2()
+        public override void InitializePhase2()
         {
             SiteVars.ReInitialize();
             reinitialized = true;


### PR DESCRIPTION
Allow Extension-Base-BDA, Extension-LinearWind, Extension-Land-Use-Change to override default implementation of InitalizePhase2() in Core-Model